### PR TITLE
Implement Board Archive functionality

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,4 +3,7 @@
     "[typescript]": {
         "editor.tabSize": 2
     },
+    "cSpell.words": [
+        "typeorm"
+    ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "editor.tabSize": 2
     },
     "cSpell.words": [
+        "dtos",
         "typeorm"
     ],
 }

--- a/src/boards/boards.mapper.ts
+++ b/src/boards/boards.mapper.ts
@@ -11,6 +11,7 @@ export class BoardMapper {
     const dto = new BoardDto();
     dto.id = entity.id;
     dto.name = entity.name;
+    dto.isArchived = entity.isArchived;
     dto.userId = entity.user?.id;
 
     dto.columns = !entity.columns ? null : entity.columns.map(columnMapper.toDto);

--- a/src/boards/dtos/board.dto.ts
+++ b/src/boards/dtos/board.dto.ts
@@ -11,6 +11,9 @@ export class BoardDto {
   @ApiProperty()
   name: string;
 
+  @ApiProperty()
+  isArchived: boolean;
+
   @ApiProperty({ type: [BoardColumnDto] })
   columns: BoardColumnDto[];
 }

--- a/src/boards/dtos/update-board.dto.ts
+++ b/src/boards/dtos/update-board.dto.ts
@@ -1,8 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 export class UpdateBoardDto {
   @ApiProperty()
+  @IsOptional()
   @IsString()
   name?: string;
+
+  @ApiProperty()
+  @IsOptional()
+  @IsBoolean()
+  isArchived?: boolean;
 }

--- a/src/boards/entities/board.entity.ts
+++ b/src/boards/entities/board.entity.ts
@@ -13,6 +13,9 @@ export class Board extends BaseEntity {
   @Column()
   name: string;
 
+  @Column({ name: 'is_archived', default: false })
+  isArchived: boolean;
+
   @OneToMany(() => BoardColumn, (column) => column.board)
   columns: BoardColumn[];
 

--- a/src/exceptions/http-exception.filter.ts
+++ b/src/exceptions/http-exception.filter.ts
@@ -19,8 +19,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
         params: request.params,
         query: request.query,
         headers: {
-          autorization: request.headers.authorization,
-          contetnType: request.headers['content-type'],
+          authorization: request.headers.authorization,
+          contentType: request.headers['content-type'],
         },
         body: request.body,
       },

--- a/src/exceptions/http-exception.filter.ts
+++ b/src/exceptions/http-exception.filter.ts
@@ -27,14 +27,21 @@ export class HttpExceptionFilter implements ExceptionFilter {
       exception,
     );
 
-    if (exception instanceof CustomHttpException) {
-      response
-        .status(exception.getStatus())
-        .json(this.formResponse(exceptionId, exception.message, exception.userFriendlyMessage));
-      return;
-    }
-
     try {
+      if (exception instanceof CustomHttpException) {
+        response
+          .status(exception.getStatus())
+          .json(this.formResponse(exceptionId, exception.message, exception.userFriendlyMessage));
+        return;
+      }
+
+      if (exception.getStatus() == 401) {
+        response
+          .status(exception.getStatus())
+          .json(this.formResponse(exceptionId, 'Unauthorized', null, null));
+        return;
+      }
+
       // Catch DTO validation exception from `class-validator`
       type ClassValidatorResponse = { message: string[] };
       const classValidatorResponse = exception.getResponse() as ClassValidatorResponse;

--- a/src/migrations/1719063577850-isArchived-board.ts
+++ b/src/migrations/1719063577850-isArchived-board.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class IsArchivedBoard1719063577850 implements MigrationInterface {
+  name = 'IsArchivedBoard1719063577850';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "boards" ADD "is_archived" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "boards" DROP COLUMN "is_archived"`);
+  }
+}


### PR DESCRIPTION
Contains DB change. A new `is_archived` column was added to the `board` table. Also, the `isArchived` property was added to the BoardDto model.

To archive `Board` use PATCH `/board/{id}` endpoint. Pass `"isArchived": false` inside of JSON body.