### PR TITLE
Apply ordering

### DIFF
--- a/src/modules/board-columns/board-columns.service.ts
+++ b/src/modules/board-columns/board-columns.service.ts
@@ -61,6 +61,7 @@ export class BoardColumnsService {
     return this.boardColumnsRepository.find({
       where: { board: { id: boardId, user: { id: userId } } },
       relations: { jobApplications: true },
+      order: { order: 'ASC', jobApplications: { createdAt: 'ASC' } },
     });
   }
 

--- a/src/modules/boards/boards.service.spec.ts
+++ b/src/modules/boards/boards.service.spec.ts
@@ -42,6 +42,7 @@ describe('BoardsService', () => {
     const boardsRepositoryMock = {
       findOneBy: jest.fn().mockImplementation(() => Promise.resolve(validBoard)),
       findBy: jest.fn().mockImplementation(() => Promise.resolve([validBoard])),
+      find: jest.fn().mockImplementation(() => Promise.resolve([validBoard])),
       create: jest.fn().mockImplementation(() => Promise.resolve(validBoard)),
       save: jest.fn().mockImplementation(() => Promise.resolve(validBoard)),
       remove: jest.fn().mockImplementation(() => Promise.resolve(validBoard)),

--- a/src/modules/boards/boards.service.ts
+++ b/src/modules/boards/boards.service.ts
@@ -45,9 +45,12 @@ export class BoardsService {
 
     const boardName = query.name?.length > 0 ? Like(`%${query.name}%`) : null;
 
-    return this.boardsRepository.findBy({
-      name: boardName,
-      user: { id: userId },
+    return this.boardsRepository.find({
+      where: {
+        name: boardName,
+        user: { id: userId },
+      },
+      order: { createdAt: 'ASC' },
     });
   }
 
@@ -58,7 +61,10 @@ export class BoardsService {
   }
 
   async getAllBoardsWithData(userId: string): Promise<Board[]> {
-    const boardsEntities = await this.boardsRepository.findBy({ user: { id: userId } });
+    const boardsEntities = await this.boardsRepository.find({
+      where: { user: { id: userId } },
+      order: { createdAt: 'ASC' },
+    });
     await Promise.all(
       boardsEntities.map(async (board) => {
         board.columns = await this.boardsColumnService.findColumns(board.id, userId);

--- a/src/modules/contacts/contact-method.controller.ts
+++ b/src/modules/contacts/contact-method.controller.ts
@@ -1,5 +1,15 @@
-import { Body, Controller, Delete, Get, Param, ParseUUIDPipe, Post, Put } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Put,
+  Query,
+} from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { AuthUserDto } from '../auth/dtos/auth.user.dto';
 import { AuthUser } from '../auth/user.decorator';
 import { ContactMethodsService } from './contact-methods.service';
@@ -19,8 +29,9 @@ export class ContactMethodsController {
     private readonly contactPhoneMapper: ContactPhoneMapper,
   ) {}
 
-  @Get('/contact-method/email/:id')
+  @Get('/contact-method/email')
   @ApiOperation({ summary: 'Gets all email contact methods from a contact' })
+  @ApiParam({ name: 'contactId', required: true })
   @ApiResponse({
     status: 200,
     description: "Contact's email added",
@@ -31,15 +42,16 @@ export class ContactMethodsController {
     description: 'Validation error',
   })
   async getContactMethodEmail(
-    @Param('id', ParseUUIDPipe) contactId: string,
+    @Query('contactId', ParseUUIDPipe) contactId: string,
     @AuthUser() user: AuthUserDto,
   ) {
     const entities = await this.contactMethodService.getContactMethodEmails(contactId, user.userId);
     return entities.map(this.contactEmailMapper.toDto);
   }
 
-  @Get('/contact-method/phone/:id')
+  @Get('/contact-method/phone')
   @ApiOperation({ summary: 'Gets all phone contact methods from a contact' })
+  @ApiParam({ name: 'contactId', required: true })
   @ApiResponse({
     status: 200,
     description: "Contact's phone added",
@@ -50,10 +62,10 @@ export class ContactMethodsController {
     description: 'Validation error',
   })
   async getContactMethodPhone(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Query('contactId', ParseUUIDPipe) contactId: string,
     @AuthUser() user: AuthUserDto,
   ) {
-    const entities = await this.contactMethodService.getContactMethodPhones(id, user.userId);
+    const entities = await this.contactMethodService.getContactMethodPhones(contactId, user.userId);
     return entities.map(this.contactPhoneMapper.toDto);
   }
 

--- a/src/modules/contacts/contact-methods.service.ts
+++ b/src/modules/contacts/contact-methods.service.ts
@@ -58,13 +58,19 @@ export class ContactMethodsService {
   async getContactMethodEmails(contactId: string, userId: string): Promise<ContactEmail[]> {
     await this.validateContactExists(contactId, userId);
 
-    return this.contactEmailsRepository.findBy({ contact: { id: contactId } });
+    return this.contactEmailsRepository.find({
+      where: { contact: { id: contactId } },
+      order: { createdAt: 'ASC' },
+    });
   }
 
   async getContactMethodPhones(contactId: string, userId: string): Promise<ContactPhone[]> {
     await this.validateContactExists(contactId, userId);
 
-    return this.contactPhonesRepository.findBy({ contact: { id: contactId } });
+    return this.contactPhonesRepository.find({
+      where: { contact: { id: contactId } },
+      order: { createdAt: 'ASC' },
+    });
   }
 
   async createContactMethodEmail(

--- a/src/modules/contacts/contacts.service.ts
+++ b/src/modules/contacts/contacts.service.ts
@@ -29,6 +29,7 @@ export class ContactsService {
     const contacts = await this.contactsRepository.find({
       where: { id: params.contactId, board: { id: params.boardId, user: { id: userId } } },
       relations: { board: true, jobApplications: true, contactEmails: true, contactPhones: true },
+      order: { createdAt: 'ASC' },
     });
     return contacts.map(this.mapper.toDto);
   }


### PR DESCRIPTION
Most of the array response data is now ordered by the `created_at` column, except for the `boardColumns` array. The `order` column now orders this `boardColumns` array.

Contains API change:
The ContactId URL param was replaced with the query param in the following endpoints:
- `/contacts/contact-method/email`
- `/contacts/contact-method/phone`